### PR TITLE
Avoid returning all managed content when there is no topic associated.

### DIFF
--- a/force-app/main/default/classes/ManagedContentController.cls
+++ b/force-app/main/default/classes/ManagedContentController.cls
@@ -80,6 +80,10 @@ public with sharing class ManagedContentController {
         
         System.debug('CMS Component Debug || Retrieving CMS Content for Community ' + communityId);
         
+        if ( topicIds.size() <= 0 ) {
+            //as no topics associated, return null instead of returning all content for a given managedContentType
+            return null;
+        }
         // convert topic IDs to names to work with the API
         List<Topic> topics = [select Name from Topic where Id in :topicIds and networkId = :communityId];
         List<String> topicNames = new List<String>();


### PR DESCRIPTION
Hi, 
We are using this pkg in YPO project.
Our requirement is when there is no topics assigned for a record, say example Account record, then no CMS content should be returned as well.

I made this fix. @ildiavolorosso  Pls review and do the needful.

Thanks